### PR TITLE
Update app

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,8 +9,8 @@ BACKEND_URL = os.getenv("BACKEND_URL")
 # Writers/adapters available
 WRITERS = [
     "Base",
-    "Darwin",
     "Dostoevsky",
+    "Fitzgerald",
     "Twain",
 ]
 WHAT_IS_THIS_APP = """

--- a/app.py
+++ b/app.py
@@ -15,13 +15,13 @@ WRITERS = [
 ]
 WHAT_IS_THIS_APP = """
 This app demos LoRA adapters fine-tuned on a base language model to mimic three famous writers with distinctive voices:
-1. Charles Darwin
-2. Fyodor Dostoevsky
+1. Fyodor Dostoevsky
+2. F. Scott Fitzgerald
 3. Mark Twain
 
 For each author, I obtained a dataset of books from [Project Gutenberg](https://www.gutenberg.org) and fine-tuned LoRA adapters using supervised fine-tuning.
 
-You can also select "Base" to generate text using the base model without any author-specific adaptation.
+You can also select "Base" to generate text using the base LLM without author-specific tuning.
 
 Source code 👉 [GitHub](https://github.com/justinpyron/impersonate-gpt)
 """

--- a/app.py
+++ b/app.py
@@ -57,6 +57,7 @@ def ping_api(
             "temperature": temperature,
             "num_tokens": int(num_tokens),
         },
+        timeout=300.0,
     )
     response.raise_for_status()
     return response.json()["generated_text"]

--- a/app.py
+++ b/app.py
@@ -1,4 +1,3 @@
-import json
 import os
 
 import httpx
@@ -60,12 +59,8 @@ def stream_api(
         timeout=300.0,
     ) as response:
         response.raise_for_status()
-        for line in response.iter_lines():
-            if line.startswith("data: "):
-                data = line[len("data: ") :]
-                if data == "[DONE]":
-                    break
-                yield json.loads(data)["token"]
+        for chunk in response.iter_text():
+            yield chunk
 
 
 st.set_page_config(page_title="ImpersonateGPT", layout="centered", page_icon="🥸")

--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 import os
 
-import requests
+import httpx
 import streamlit as st
 
 # Backend configuration
@@ -49,7 +49,7 @@ def ping_api(
         raise ValueError("BACKEND_URL environment variable is not set")
 
     # Make request to the generate endpoint
-    response = requests.post(
+    response = httpx.post(
         url=f"{BACKEND_URL}/generate/{adapter_name}",
         headers={"Content-Type": "application/json"},
         json={

--- a/app.py
+++ b/app.py
@@ -87,7 +87,9 @@ with st.form("inputs", enter_to_submit=False, border=False):
             w for w in WRITERS if w in selected_writers
         ]  # Preserve order
     with col2:
-        with st.expander("Settings"):
+        with st.expander(
+            "Settings"
+        ):  # TODO: Don't put these in an expander; put each in its own column
             temperature = st.slider(
                 "Temperature",
                 min_value=0.1,
@@ -106,7 +108,7 @@ with st.form("inputs", enter_to_submit=False, border=False):
             )
     submitted = st.form_submit_button(
         "Generate text", use_container_width=True, type="primary"
-    )
+    )  # TODO: Change to just "Generate"
 
 if submitted and len(selected_writers) > 0:
     columns = st.columns(len(selected_writers))

--- a/app.py
+++ b/app.py
@@ -3,10 +3,7 @@ import os
 import httpx
 import streamlit as st
 
-# Backend configuration
 BACKEND_URL = os.getenv("BACKEND_URL")
-
-# Writers/adapters available
 WRITERS = [
     "Base",
     "Dostoevsky",

--- a/app.py
+++ b/app.py
@@ -114,11 +114,23 @@ if submitted and len(selected_writers) > 0:
         with col:
             with st.container(border=True):
                 st.markdown(f"#### {writer} says...")
+                placeholder = st.empty()
+                placeholder.markdown("⏳ Waiting for server...")
+
+                def stream_with_status(generator, placeholder):
+                    for i, chunk in enumerate(generator):
+                        if i == 0:
+                            placeholder.empty()
+                        yield chunk
+
                 st.write_stream(
-                    stream_api(
-                        writer.lower(),
-                        text_seed,
-                        temperature,
-                        num_tokens,
+                    stream_with_status(
+                        stream_api(
+                            writer.lower(),
+                            text_seed,
+                            temperature,
+                            num_tokens,
+                        ),
+                        placeholder,
                     )
                 )

--- a/app.py
+++ b/app.py
@@ -67,26 +67,6 @@ st.set_page_config(page_title="ImpersonateGPT", layout="centered", page_icon="�
 st.title("ImpersonateGPT 🥸")
 with st.expander("What is this app?"):
     st.markdown(WHAT_IS_THIS_APP)
-footer_html = """
-    <style>
-        .footer {
-            position: fixed;
-            left: 0;
-            bottom: 0;
-            width: 100%;
-            height: 35px;
-            color: white;
-            background-color: #262730;
-            text-align: center;
-            padding: 2px;
-            opacity: 1;
-        }
-    </style>
-    <div class="footer">
-        <p>⚠️ It may take up to two minutes for the inference server to start after the first 'Generate text' button click.</p>
-    </div>
-"""
-st.markdown(footer_html, unsafe_allow_html=True)
 
 with st.form("inputs", enter_to_submit=False, border=False):
     text_seed = st.text_area(
@@ -141,4 +121,3 @@ if submitted and len(selected_writers) > 0:
                         num_tokens,
                     )
                 st.markdown(generated_text)
-st.markdown(footer_html, unsafe_allow_html=True)

--- a/app.py
+++ b/app.py
@@ -1,42 +1,64 @@
+import os
+
 import requests
 import streamlit as st
 
-URL = "https://impersonate-gpt-623148967155.us-central1.run.app"
+# Backend configuration
+BACKEND_URL = os.getenv("BACKEND_URL")
+
+# Writers/adapters available
 WRITERS = [
-    "GPT2",
+    "Base",
     "Darwin",
     "Dostoevsky",
-    "Fitzgerald",
     "Twain",
 ]
 WHAT_IS_THIS_APP = """
-This app demos [GPT2 models](https://huggingface.co/openai-community/gpt2) fine-tuned to mimic four famous writers with distinctive voices:
+This app demos LoRA adapters fine-tuned on a base language model to mimic three famous writers with distinctive voices:
 1. Charles Darwin
 2. Fyodor Dostoevsky
-3. F. Scott Fitzgerald
-4. Mark Twain
+3. Mark Twain
 
-For each author, I obtained a dataset of four books from [Project Gutenberg](https://www.gutenberg.org). Each model was fine-tuned on these books for 10 epochs on an Nvidia L4 GPU on a Google Compute Engine VM.
+For each author, I obtained a dataset of books from [Project Gutenberg](https://www.gutenberg.org) and fine-tuned LoRA adapters using supervised fine-tuning.
+
+You can also select "Base" to generate text using the base model without any author-specific adaptation.
 
 Source code 👉 [GitHub](https://github.com/justinpyron/impersonate-gpt)
 """
 
 
 def ping_api(
-    endpoint: str,
+    adapter_name: str,
     text: str,
     temperature: float = 1,
     num_tokens: float = 70,
 ) -> str:
+    """
+    Call the backend to generate text.
+
+    Args:
+        adapter_name: The adapter to use (base, darwin, dostoevsky, twain)
+        text: The seed text to generate from
+        temperature: Sampling temperature
+        num_tokens: Number of tokens to generate
+
+    Returns:
+        Generated text string
+    """
+    if not BACKEND_URL:
+        raise ValueError("BACKEND_URL environment variable is not set")
+
+    # Make request to the generate endpoint
     response = requests.post(
-        url=f"{URL}/{endpoint}",
+        url=f"{BACKEND_URL}/generate/{adapter_name}",
         headers={"Content-Type": "application/json"},
         json={
             "text": text,
             "temperature": temperature,
-            "num_tokens": num_tokens,
+            "num_tokens": int(num_tokens),
         },
     )
+    response.raise_for_status()
     return response.json()["generated_text"]
 
 

--- a/app.py
+++ b/app.py
@@ -105,8 +105,8 @@ with st.form("inputs", enter_to_submit=False, border=False):
             help="The number of tokens to generate",
         )
     submitted = st.form_submit_button(
-        "Generate text", use_container_width=True, type="primary"
-    )  # TODO: Change to just "Generate"
+        "Generate", use_container_width=True, type="primary"
+    )
 
 if submitted and len(selected_writers) > 0:
     columns = st.columns(len(selected_writers))

--- a/app.py
+++ b/app.py
@@ -75,7 +75,7 @@ with st.form("inputs", enter_to_submit=False, border=False):
         "",
         help="The app will generate text starting from what you enter here",
     )
-    col1, col2 = st.columns([3, 2])
+    col1, col2, col3 = st.columns([2.5, 1, 1])
     with col1:
         selected_writers = st.segmented_control(
             "Writers to mimic",
@@ -87,25 +87,23 @@ with st.form("inputs", enter_to_submit=False, border=False):
             w for w in WRITERS if w in selected_writers
         ]  # Preserve order
     with col2:
-        with st.expander(
-            "Settings"
-        ):  # TODO: Don't put these in an expander; put each in its own column
-            temperature = st.slider(
-                "Temperature",
-                min_value=0.1,
-                max_value=2.0,
-                step=0.1,
-                value=1.0,
-                help="Controls randomness of generated text. Lower values are less random.",
-            )
-            num_tokens = st.slider(
-                "Number of tokens",
-                min_value=10,
-                max_value=200,
-                step=10,
-                value=80,
-                help="The number of tokens to generate",
-            )
+        temperature = st.slider(
+            "Temperature",
+            min_value=0.1,
+            max_value=2.0,
+            step=0.1,
+            value=1.0,
+            help="Controls randomness of generated text. Lower values are less random.",
+        )
+    with col3:
+        num_tokens = st.slider(
+            "Number of tokens",
+            min_value=10,
+            max_value=200,
+            step=10,
+            value=80,
+            help="The number of tokens to generate",
+        )
     submitted = st.form_submit_button(
         "Generate text", use_container_width=True, type="primary"
     )  # TODO: Change to just "Generate"

--- a/backend.py
+++ b/backend.py
@@ -75,10 +75,10 @@ class Server:
 
     def generate(
         self,
+        adapter_name: str,
         text: str,
         temperature: float,
         num_tokens: int,
-        adapter_name: str,
     ):
         """
         Generate text continuation, yielding token chunks as they are produced.
@@ -164,10 +164,10 @@ class Server:
 
             return StreamingResponse(
                 self.generate(
+                    adapter_name=adapter_name,
                     text=request.text,
                     temperature=request.temperature,
                     num_tokens=request.num_tokens,
-                    adapter_name=adapter_name,
                 ),
                 media_type="text/plain",
             )

--- a/backend.py
+++ b/backend.py
@@ -131,7 +131,10 @@ class Server:
     @modal.asgi_app()
     def fastapi_server(self):
         """Create and configure the FastAPI application."""
+        import json
+
         from fastapi import FastAPI, HTTPException
+        from fastapi.responses import StreamingResponse
         from pydantic import BaseModel
 
         class GenerateRequest(BaseModel):
@@ -139,38 +142,39 @@ class Server:
             temperature: float
             num_tokens: int
 
-        class GenerateResponse(BaseModel):
-            generated_text: str
-
         server = FastAPI(title="ImpersonateGPT API")
 
-        @server.post("/generate/{adapter_name}", response_model=GenerateResponse)
+        @server.post("/generate/{adapter_name}")
         def generate_endpoint(
             adapter_name: str, request: GenerateRequest
-        ) -> GenerateResponse:
+        ) -> StreamingResponse:
             """
-            Generate text continuation from seed text using specified adapter.
+            Stream generated text as Server-Sent Events.
 
             Args:
-                adapter_name: Name of the LoRA adapter to use (darwin, dostoevsky, twain) or "base" for base model
+                adapter_name: Name of the LoRA adapter or "base"
                 request: Request containing seed text and generation parameters
 
             Returns:
-                Response with the full generated text
+                SSE stream of token chunks
             """
             if adapter_name != "base" and adapter_name not in ADAPTERS:
                 raise HTTPException(
                     status_code=404,
-                    detail=f"Adapter '{adapter_name}' not found. Available adapters: {sorted(list(ADAPTERS.keys()))}. Or 'base' for base model.",
+                    detail=f"Adapter '{adapter_name}' not found. Available: {sorted(list(ADAPTERS.keys()))} or 'base'.",
                 )
 
-            generated_text = self.generate(
-                text=request.text,
-                temperature=request.temperature,
-                num_tokens=request.num_tokens,
-                adapter_name=adapter_name,
-            )
-            return GenerateResponse(generated_text=generated_text)
+            def event_stream():
+                for chunk in self.generate(
+                    text=request.text,
+                    temperature=request.temperature,
+                    num_tokens=request.num_tokens,
+                    adapter_name=adapter_name,
+                ):
+                    yield f"data: {json.dumps({'token': chunk})}\n\n"
+                yield "data: [DONE]\n\n"
+
+            return StreamingResponse(event_stream(), media_type="text/event-stream")
 
         @server.get("/adapters")
         def list_adapters():

--- a/backend.py
+++ b/backend.py
@@ -14,7 +14,7 @@ ADAPTERS = {
     "dostoevsky": "weights_sft/dostoevsky_20260206T162221Z",
     "twain": "weights_sft/twain_20260206T145643Z",
 }
-SCALEDOWN_WINDOW_SECONDS = 60
+SCALEDOWN_WINDOW_SECONDS = 300
 
 # =============================================================================
 # Modal Setup

--- a/backend.py
+++ b/backend.py
@@ -10,6 +10,11 @@ VOLUME_NAME = "impersonate-gpt"
 VOLUME_MOUNT_PATH = "/data"
 MODEL_FOLDER_PATH = "gemma-3-270m"
 SCALEDOWN_WINDOW_SECONDS = 60
+ADAPTER_PATHS = {
+    "darwin": "PLACEHOLDER_PATH",
+    "dostoevsky": "PLACEHOLDER_PATH",
+    "twain": "PLACEHOLDER_PATH",
+}
 
 # =============================================================================
 # Modal Setup
@@ -18,8 +23,9 @@ SCALEDOWN_WINDOW_SECONDS = 60
 app = modal.App("impersonate-gpt")
 
 image = modal.Image.debian_slim(python_version="3.12").pip_install(
-    "torch==2.10.0",
+    "torch==2.10.0",  # TODO: Remove
     "transformers==4.55.4",
+    "peft==0.14.0",
     "fastapi==0.128.0",
     "pydantic==2.12.5",
 )
@@ -43,6 +49,7 @@ class Server:
     @modal.enter()
     def load_model_and_tokenizer(self):
         """Load model and tokenizer on container startup."""
+        from peft import PeftModel
         from transformers import AutoModelForCausalLM, AutoTokenizer
 
         model_path = f"{VOLUME_MOUNT_PATH}/{MODEL_FOLDER_PATH}"
@@ -50,15 +57,29 @@ class Server:
         # Load tokenizer
         self.tokenizer = AutoTokenizer.from_pretrained(model_path)
 
-        # Load model to CPU
-        self.model = AutoModelForCausalLM.from_pretrained(model_path)
-        self.model.eval()
+        # Load base model
+        base_model = AutoModelForCausalLM.from_pretrained(model_path)
+        base_model.eval()
+
+        # Load first adapter
+        adapter_names = list(ADAPTER_PATHS.keys())
+        first_adapter_name = adapter_names[0]
+        first_adapter_path = f"{VOLUME_MOUNT_PATH}/{ADAPTER_PATHS[first_adapter_name]}"
+        self.model = PeftModel.from_pretrained(
+            base_model, first_adapter_path, adapter_name=first_adapter_name
+        )
+
+        # Load remaining adapters
+        for adapter_name in adapter_names[1:]:
+            adapter_path = f"{VOLUME_MOUNT_PATH}/{ADAPTER_PATHS[adapter_name]}"
+            self.model.load_adapter(adapter_path, adapter_name=adapter_name)
 
     def generate(
         self,
         text: str,
         temperature: float,
         num_tokens: int,
+        adapter_name: str,
     ) -> str:
         """
         Generate text continuation for a single input.
@@ -67,10 +88,14 @@ class Server:
             text: The seed text to continue
             temperature: Temperature for sampling (higher = more random)
             num_tokens: Number of new tokens to generate
+            adapter_name: Name of the LoRA adapter to use
 
         Returns:
             The full generated text (seed + continuation)
         """
+        # Switch to the requested adapter
+        self.model.set_adapter(adapter_name)
+
         # Tokenize input
         input_tokens = self.tokenizer(text, return_tensors="pt")
 
@@ -91,7 +116,7 @@ class Server:
     @modal.asgi_app()
     def fastapi_server(self):
         """Create and configure the FastAPI application."""
-        from fastapi import FastAPI
+        from fastapi import FastAPI, HTTPException
         from pydantic import BaseModel
 
         class GenerateRequest(BaseModel):
@@ -104,23 +129,38 @@ class Server:
 
         server = FastAPI(title="ImpersonateGPT API")
 
-        @server.post("/generate", response_model=GenerateResponse)
-        def generate_endpoint(request: GenerateRequest) -> GenerateResponse:
+        @server.post("/generate/{adapter_name}", response_model=GenerateResponse)
+        def generate_endpoint(
+            adapter_name: str, request: GenerateRequest
+        ) -> GenerateResponse:
             """
-            Generate text continuation from seed text.
+            Generate text continuation from seed text using specified adapter.
 
             Args:
+                adapter_name: Name of the LoRA adapter to use (darwin, dostoevsky, twain)
                 request: Request containing seed text and generation parameters
 
             Returns:
                 Response with the full generated text
             """
+            if adapter_name not in ADAPTER_PATHS:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Adapter '{adapter_name}' not found. Available adapters: {list(ADAPTER_PATHS.keys())}",
+                )
+
             generated_text = self.generate(
                 text=request.text,
                 temperature=request.temperature,
                 num_tokens=request.num_tokens,
+                adapter_name=adapter_name,
             )
             return GenerateResponse(generated_text=generated_text)
+
+        @server.get("/adapters")
+        def list_adapters():
+            """List all available adapters."""
+            return {"adapters": list(ADAPTER_PATHS.keys())}
 
         @server.get("/health")
         async def health_check():

--- a/backend.py
+++ b/backend.py
@@ -46,34 +46,20 @@ class Server:
     @modal.enter()
     def load_model_and_tokenizer(self):
         """Load model and tokenizer on container startup."""
-        import time
-
         import torch
         from transformers import AutoModelForCausalLM, AutoTokenizer
-
-        start_total = time.time()
 
         model_path = f"{VOLUME_MOUNT_PATH}/{MODEL_FOLDER_PATH}"
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
 
-        print(f"[TIMING] (Loading) Device: {self.device}")
-
         # Load tokenizer
-        start = time.time()
         self.tokenizer = AutoTokenizer.from_pretrained(model_path)
-        print(f"[TIMING] (Loading) Tokenizer loaded in {time.time() - start:.2f}s")
 
         # Load model directly to GPU
-        start = time.time()
         self.model = AutoModelForCausalLM.from_pretrained(model_path, device_map="auto")
-        print(f"[TIMING] (Loading) Model loaded in {time.time() - start:.2f}s")
 
         # Set to eval mode
         self.model.eval()
-
-        print(
-            f"[TIMING] (Loading) Total model loading: {time.time() - start_total:.2f}s"
-        )
 
     def generate(
         self,
@@ -92,33 +78,19 @@ class Server:
         Returns:
             The full generated text (seed + continuation)
         """
-        import time
-
-        start_total = time.time()
-
         # Tokenize input and move to GPU
-        start = time.time()
         input_tokens = self.tokenizer(text, return_tensors="pt").to(self.device)
-        print(f"[TIMING] (Inference) Tokenization: {time.time() - start:.2f}s")
 
         # Generate continuation (output stays on GPU)
-        start = time.time()
         output_tokens = self.model.generate(
             **input_tokens,
             max_new_tokens=num_tokens,
             temperature=temperature,
         )
-        print(f"[TIMING] (Inference) Generation: {time.time() - start:.2f}s")
 
         # Decode and return full text (decoder handles device transfer internally)
-        start = time.time()
         generated_text = self.tokenizer.decode(
             output_tokens[0], skip_special_tokens=True
-        )
-        print(f"[TIMING] (Inference) Decoding: {time.time() - start:.2f}s")
-
-        print(
-            f"[TIMING] (Inference) Total generate call: {time.time() - start_total:.2f}s"
         )
 
         return generated_text

--- a/backend.py
+++ b/backend.py
@@ -11,7 +11,10 @@ VOLUME_MOUNT_PATH = "/data"
 MODEL_FOLDER_PATH = "gemma-3-270m"
 ADAPTERS = {
     "darwin": "weights_sft/darwin_20260206T162059Z",
+    "dickens": "weights_sft/dickens_20260206T162433Z",
     "dostoevsky": "weights_sft/dostoevsky_20260206T162221Z",
+    "doyle": "weights_sft/doyle_20260206T162518Z",
+    "fitzgerald": "weights_sft/fitzgerald_20260206T162358Z",
     "twain": "weights_sft/twain_20260206T145643Z",
 }
 SCALEDOWN_WINDOW_SECONDS = 600

--- a/backend.py
+++ b/backend.py
@@ -14,7 +14,7 @@ ADAPTERS = {
     "dostoevsky": "weights_sft/dostoevsky_20260206T162221Z",
     "twain": "weights_sft/twain_20260206T145643Z",
 }
-SCALEDOWN_WINDOW_SECONDS = 300
+SCALEDOWN_WINDOW_SECONDS = 600
 
 # =============================================================================
 # Modal Setup

--- a/backend.py
+++ b/backend.py
@@ -23,10 +23,10 @@ SCALEDOWN_WINDOW_SECONDS = 60
 app = modal.App("impersonate-gpt")
 
 image = modal.Image.debian_slim(python_version="3.12").pip_install(
-    "transformers==4.55.4",
-    "peft==0.14.0",
-    "fastapi==0.128.0",
-    "pydantic==2.12.5",
+    "transformers",
+    "peft",
+    "fastapi",
+    "pydantic",
 )
 
 volume = modal.Volume.from_name(VOLUME_NAME)
@@ -61,7 +61,7 @@ class Server:
         base_model.eval()
 
         # Load first adapter
-        adapter_names = sorted(list(ADAPTERS.keys)())
+        adapter_names = sorted(list(ADAPTERS.keys()))
         first_adapter_name = adapter_names[0]
         first_adapter_path = f"{VOLUME_MOUNT_PATH}/{ADAPTERS[first_adapter_name]}"
         self.model = PeftModel.from_pretrained(

--- a/poetry.lock
+++ b/poetry.lock
@@ -6076,4 +6076,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "1bcced64f9b64e071ab59b5abd05c0fd78b39342ac8630be0b209c635daafd5b"
+content-hash = "b13680370c776ad36c94ea007db1e9bba30c743d854080322c63cc132f6fc3c6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ accelerate = "^1.12.0"
 datasets = "^4.5.0"
 trl = "^0.27.2"
 peft = "^0.18.1"
+httpx = "^0.28.1"
 
 
 [build-system]


### PR DESCRIPTION
## Refactor backend and frontend for multi-adapter LoRA serving with streaming

### Summary

- **Multi-adapter backend**: Refactored `backend.py` to load a base model with multiple LoRA adapters (one per author) at startup, serving each through a dynamic `/generate/{adapter_name}` endpoint. Supports `"base"` for the unmodified model via `disable_adapter()`.
- **Token streaming**: Replaced the blocking generate-then-return pattern with real-time token streaming end-to-end: `TextIteratorStreamer` in the backend, `StreamingResponse` over plain text in FastAPI, `httpx.stream()` in the frontend, and `st.write_stream()` in the Streamlit UI.
- **Frontend modernization**: Rewired `app.py` to call the Modal backend via a `BACKEND_URL` environment variable, switched HTTP client from `requests` to `httpx`, replaced the hacky HTML footer with a clean cold-start placeholder that disappears on first token, and moved settings into a cleaner 3-column layout.
- **Leaner deployment**: Removed GPU/CUDA dependencies, timing/logging instrumentation, and `accelerate` for a faster-booting CPU-only container.

### Changes

| File | What changed |
|---|---|
| `backend.py` | Removed timing/logging, GPU support, and `accelerate`. Added PEFT for multi-adapter loading. Converted `generate()` to a streaming generator using `TextIteratorStreamer` + background thread. Replaced JSON endpoint with `StreamingResponse` over plain text. Added `/adapters` and base model support. |
| `app.py` | Replaced hardcoded GCP URL with `BACKEND_URL` env var. Switched from `requests` to `httpx` with streaming. Replaced `st.markdown` with `st.write_stream`. Removed HTML footer. Added cold-start placeholder. Moved sliders out of expander into 3-column layout. |
| `pyproject.toml` | Added `httpx` dependency. |